### PR TITLE
"Multi" is not defined for resolutions > 4K

### DIFF
--- a/Shaders/Depth_Cues.fx
+++ b/Shaders/Depth_Cues.fx
@@ -51,7 +51,7 @@
 #elif (BUFFER_HEIGHT <= 2160)
 	#define Multi 2
 #else
-	#define Quality 2.5
+	#define Multi 2.5
 #endif
 
 // It is best to run Smart Sharp after tonemapping.


### PR DESCRIPTION
Hi, I found a tiny problem with a shader (looks like a refactoring artefact). The issue went unnoticed until now because it only occurs at buffer heights > 2160