### PR TITLE
fix depth cues compile failed on screen resolution larger than 2160

### DIFF
--- a/Shaders/Depth_Cues.fx
+++ b/Shaders/Depth_Cues.fx
@@ -51,7 +51,7 @@
 #elif (BUFFER_HEIGHT <= 2160)
 	#define Multi 2
 #else
-	#define Quality 2.5
+	#define Multi 2.5
 #endif
 
 // It is best to run Smart Sharp after tonemapping.


### PR DESCRIPTION
An obvious change, see title.