### PR TITLE
Rewrite NFAA.fx

### DIFF
--- a/Shaders/NFAA.fx
+++ b/Shaders/NFAA.fx
@@ -228,20 +228,25 @@ float4 NFAA(float2 texcoord)
 
 		// calculate x/y coordinates on this slope at specified distance to origin
 		// parallel
-		float2 d0, d1;
+		float2 d0, d1, d2;
 		d0.x = sqrt(1.0 / (1 + m*m));
 		d0.y = m * d0.x;
 
-		// perpendicular
-		m = -rcp(m);
 		d1.x = sqrt(0.25 / (1 + m*m));
 		d1.y = m * d1.x;
 
-        float4 t0 = tex2Dlod(ReShade::BackBuffer, float4(mad(d0, BUFFER_PIXEL_SIZE, texcoord), 0.0, 0.0));
-		float4 t1 = tex2Dlod(ReShade::BackBuffer, float4(mad(-d0, BUFFER_PIXEL_SIZE, texcoord), 0.0, 0.0));
-		float4 t2 = tex2Dlod(ReShade::BackBuffer, float4(mad(d1, BUFFER_PIXEL_SIZE, texcoord), 0.0, 0.0));
-		float4 t3 = tex2Dlod(ReShade::BackBuffer, float4(mad(-d1, BUFFER_PIXEL_SIZE, texcoord), 0.0, 0.0));
-		color = lerp((color + t0 + t1 + t2 + t3) / 5, color, mask);
+		// perpendicular
+		m = -rcp(m);
+		d2.x = sqrt(1.0 / (1 + m*m));
+		d2.y = m * d0.x;
+
+        float4 t0 = 0.3 * tex2Dlod(ReShade::BackBuffer, float4(mad(d0, BUFFER_PIXEL_SIZE, texcoord), 0.0, 0.0));
+		float4 t1 = 0.3 * tex2Dlod(ReShade::BackBuffer, float4(mad(-d0, BUFFER_PIXEL_SIZE, texcoord), 0.0, 0.0));
+		float4 t2 = 0.7 * tex2Dlod(ReShade::BackBuffer, float4(mad(d1, BUFFER_PIXEL_SIZE, texcoord), 0.0, 0.0));
+		float4 t3 = 0.7 * tex2Dlod(ReShade::BackBuffer, float4(mad(-d1, BUFFER_PIXEL_SIZE, texcoord), 0.0, 0.0));
+		float4 t4 = 0.5 * tex2Dlod(ReShade::BackBuffer, float4(mad(d2, BUFFER_PIXEL_SIZE, texcoord), 0.0, 0.0));
+		float4 t5 = 0.5 * tex2Dlod(ReShade::BackBuffer, float4(mad(-d2, BUFFER_PIXEL_SIZE, texcoord), 0.0, 0.0));
+		color = lerp((color + t0 + t1 + t2 + t3 + t4 + t5) / 4, color, mask);
     }
 
 	// DebugOutput

--- a/Shaders/NFAA.fx
+++ b/Shaders/NFAA.fx
@@ -70,25 +70,9 @@ uniform int View_Mode <
     ui_category = "NFAA";
 > = 0;
 
-uniform bool HFR_AA <
-    ui_label = "HFR AA";
-    ui_tooltip = "This allows most monitors to assist in AA if your FPS is 60 or above and Locked to your monitors refresh-rate.";
-    ui_category = "HFRAA";
-> = false;
-
-uniform float HFR_Adjust <
-    ui_type = "drag";
-    ui_min = 0.0; ui_max = 1.0;
-    ui_label = "HFR AA Adjustment";
-    ui_tooltip = "Use this to adjust HFR AA.\n"
-                 "Default is 1.00";
-    ui_category = "HFRAA";
-> = 0.5;
-
 //Total amount of frames since the game started.
 uniform uint framecount < source = "framecount"; >;
 ////////////////////////////////////////////////////////////NFAA////////////////////////////////////////////////////////////////////
-#define Alternate framecount % 2 == 0
 #define pix float2(BUFFER_RCP_WIDTH, BUFFER_RCP_HEIGHT)
 
 texture BackBufferTex : COLOR;
@@ -174,14 +158,6 @@ float4 Out(float4 position : SV_Position, float2 texcoord : TEXCOORD) : SV_Targe
     return float4(Color,1.);
 }
 
-float4 PostFilter(float4 position : SV_Position, float2 texcoord : TEXCOORD) : SV_Target
-{ float Shift;
-  if(Alternate && HFR_AA)
-    Shift = pix.x;
-
-    return tex2D(BackBuffer, texcoord +  float2(Shift * saturate(HFR_Adjust),0.0));
-}
-
 ///////////////////////////////////////////////////////////ReShade.fxh/////////////////////////////////////////////////////////////
 
 // Vertex shader generating a triangle covering the entire screen
@@ -199,11 +175,6 @@ technique Normal_Filter_Anti_Aliasing
         {
             VertexShader = PostProcessVS;
             PixelShader = Out;
-        }
-            pass HFR_AA
-        {
-            VertexShader = PostProcessVS;
-            PixelShader = PostFilter;
         }
 
 }

--- a/Shaders/NFAA.fx
+++ b/Shaders/NFAA.fx
@@ -40,49 +40,49 @@
  //*
  //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 uniform int AA_Adjust <
-	ui_type = "drag";
-	ui_min = 1; ui_max = 128;
-	ui_label = "AA Power";
-	ui_tooltip = "Use this to adjust the AA power.\n"
-				 "Default is 16";
-	ui_category = "NFAA";
+    ui_type = "drag";
+    ui_min = 1; ui_max = 128;
+    ui_label = "AA Power";
+    ui_tooltip = "Use this to adjust the AA power.\n"
+                 "Default is 16";
+    ui_category = "NFAA";
 > = 16;
 
 uniform float Mask_Adjust <
-	ui_type = "drag";
-	ui_min = 0.0; ui_max = 4.0;
-	ui_label = "Mask Adjustment";
-	ui_tooltip = "Use this to adjust the Mask.\n"
-				 "Default is 1.00";
-	ui_category = "NFAA";
+    ui_type = "drag";
+    ui_min = 0.0; ui_max = 4.0;
+    ui_label = "Mask Adjustment";
+    ui_tooltip = "Use this to adjust the Mask.\n"
+                 "Default is 1.00";
+    ui_category = "NFAA";
 > = 1.00;
 
 uniform int View_Mode <
-	ui_type = "combo";
-	ui_items = "NFAA\0Mask View\0Normals\0DLSS\0";
-	ui_label = "View Mode";
-	ui_tooltip = "This is used to select the normal view output or debug view.\n"
-				 "NFAA Masked gives you a sharper image with applyed Normals AA.\n"
-				 "Masked View gives you a view of the edge detection.\n"
-				 "Normals gives you an view of the normals created.\n"
-				 "DLSS is NV_AI_DLSS Parody experiance..........\n"
-				 "Default is NFAA.";
-	ui_category = "NFAA";
+    ui_type = "combo";
+    ui_items = "NFAA\0Mask View\0Normals\0DLSS\0";
+    ui_label = "View Mode";
+    ui_tooltip = "This is used to select the normal view output or debug view.\n"
+                 "NFAA Masked gives you a sharper image with applyed Normals AA.\n"
+                 "Masked View gives you a view of the edge detection.\n"
+                 "Normals gives you an view of the normals created.\n"
+                 "DLSS is NV_AI_DLSS Parody experiance..........\n"
+                 "Default is NFAA.";
+    ui_category = "NFAA";
 > = 0;
 
 uniform bool HFR_AA <
-	ui_label = "HFR AA";
-	ui_tooltip = "This allows most monitors to assist in AA if your FPS is 60 or above and Locked to your monitors refresh-rate.";
-	ui_category = "HFRAA";
+    ui_label = "HFR AA";
+    ui_tooltip = "This allows most monitors to assist in AA if your FPS is 60 or above and Locked to your monitors refresh-rate.";
+    ui_category = "HFRAA";
 > = false;
 
 uniform float HFR_Adjust <
-	ui_type = "drag";
-	ui_min = 0.0; ui_max = 1.0;
-	ui_label = "HFR AA Adjustment";
-	ui_tooltip = "Use this to adjust HFR AA.\n"
-				 "Default is 1.00";
-	ui_category = "HFRAA";
+    ui_type = "drag";
+    ui_min = 0.0; ui_max = 1.0;
+    ui_label = "HFR AA Adjustment";
+    ui_tooltip = "Use this to adjust HFR AA.\n"
+                 "Default is 1.00";
+    ui_category = "HFRAA";
 > = 0.5;
 
 //Total amount of frames since the game started.
@@ -95,104 +95,104 @@ uniform float timer < source = "timer"; >;
 texture BackBufferTex : COLOR;
 
 sampler BackBuffer
-	{
-		Texture = BackBufferTex;
-	};
+    {
+        Texture = BackBufferTex;
+    };
 
 void A0(float2 texcoord,float PosX,float PosY,inout float D, inout float E, inout float P, inout float T, inout float H, inout float III, inout float DD )
 {
-	float PosXD = -0.035+PosX, offsetD = 0.001;D = all( abs(float2( texcoord.x -PosXD, texcoord.y-PosY)) < float2(0.0025,0.009));D -= all( abs(float2( texcoord.x -PosXD-offsetD, texcoord.y-PosY)) < float2(0.0025,0.007));
-	float PosXE = -0.028+PosX, offsetE = 0.0005;E = all( abs(float2( texcoord.x -PosXE, texcoord.y-PosY)) < float2(0.003,0.009));E -= all( abs(float2( texcoord.x -PosXE-offsetE, texcoord.y-PosY)) < float2(0.0025,0.007));E += all( abs(float2( texcoord.x -PosXE, texcoord.y-PosY)) < float2(0.003,0.001));
-	float PosXP = -0.0215+PosX, PosYP = -0.0025+PosY, offsetP = 0.001, offsetP1 = 0.002;P = all( abs(float2( texcoord.x -PosXP, texcoord.y-PosYP)) < float2(0.0025,0.009*0.775));P -= all( abs(float2( texcoord.x -PosXP-offsetP, texcoord.y-PosYP)) < float2(0.0025,0.007*0.680));float C[1];P += all( abs(float2( texcoord.x -PosXP+offsetP1, texcoord.y-PosY)) < float2(0.0005,0.009));	
-	float PosXT = -0.014+PosX, PosYT = -0.008+PosY;T = all( abs(float2( texcoord.x -PosXT, texcoord.y-PosYT)) < float2(0.003,0.001));T += all( abs(float2( texcoord.x -PosXT, texcoord.y-PosY)) < float2(0.000625,0.009));
-	float PosXH = -0.0072+PosX;H = all( abs(float2( texcoord.x -PosXH, texcoord.y-PosY)) < float2(0.002,0.001));H -= all( abs(float2( texcoord.x -PosXH, texcoord.y-PosY)) < float2(0.002,0.009));H += all( abs(float2( texcoord.x -PosXH, texcoord.y-PosY)) < float2(0.00325,0.009));
-	float offsetFive = 0.001, PosX3 = -0.001+PosX;III = all( abs(float2( texcoord.x -PosX3, texcoord.y-PosY)) < float2(0.002,0.009));III -= all( abs(float2( texcoord.x -PosX3 - offsetFive, texcoord.y-PosY)) < float2(0.003,0.007));III += all( abs(float2( texcoord.x -PosX3, texcoord.y-PosY)) < float2(0.002,0.001));
-	float PosXDD = 0.006+PosX, offsetDD = 0.001;DD = all( abs(float2( texcoord.x -PosXDD, texcoord.y-PosY)) < float2(0.0025,0.009));DD -= all( abs(float2( texcoord.x -PosXDD-offsetDD, texcoord.y-PosY)) < float2(0.0025,0.007));
+    float PosXD = -0.035+PosX, offsetD = 0.001;D = all( abs(float2( texcoord.x -PosXD, texcoord.y-PosY)) < float2(0.0025,0.009));D -= all( abs(float2( texcoord.x -PosXD-offsetD, texcoord.y-PosY)) < float2(0.0025,0.007));
+    float PosXE = -0.028+PosX, offsetE = 0.0005;E = all( abs(float2( texcoord.x -PosXE, texcoord.y-PosY)) < float2(0.003,0.009));E -= all( abs(float2( texcoord.x -PosXE-offsetE, texcoord.y-PosY)) < float2(0.0025,0.007));E += all( abs(float2( texcoord.x -PosXE, texcoord.y-PosY)) < float2(0.003,0.001));
+    float PosXP = -0.0215+PosX, PosYP = -0.0025+PosY, offsetP = 0.001, offsetP1 = 0.002;P = all( abs(float2( texcoord.x -PosXP, texcoord.y-PosYP)) < float2(0.0025,0.009*0.775));P -= all( abs(float2( texcoord.x -PosXP-offsetP, texcoord.y-PosYP)) < float2(0.0025,0.007*0.680));float C[1];P += all( abs(float2( texcoord.x -PosXP+offsetP1, texcoord.y-PosY)) < float2(0.0005,0.009));    
+    float PosXT = -0.014+PosX, PosYT = -0.008+PosY;T = all( abs(float2( texcoord.x -PosXT, texcoord.y-PosYT)) < float2(0.003,0.001));T += all( abs(float2( texcoord.x -PosXT, texcoord.y-PosY)) < float2(0.000625,0.009));
+    float PosXH = -0.0072+PosX;H = all( abs(float2( texcoord.x -PosXH, texcoord.y-PosY)) < float2(0.002,0.001));H -= all( abs(float2( texcoord.x -PosXH, texcoord.y-PosY)) < float2(0.002,0.009));H += all( abs(float2( texcoord.x -PosXH, texcoord.y-PosY)) < float2(0.00325,0.009));
+    float offsetFive = 0.001, PosX3 = -0.001+PosX;III = all( abs(float2( texcoord.x -PosX3, texcoord.y-PosY)) < float2(0.002,0.009));III -= all( abs(float2( texcoord.x -PosX3 - offsetFive, texcoord.y-PosY)) < float2(0.003,0.007));III += all( abs(float2( texcoord.x -PosX3, texcoord.y-PosY)) < float2(0.002,0.001));
+    float PosXDD = 0.006+PosX, offsetDD = 0.001;DD = all( abs(float2( texcoord.x -PosXDD, texcoord.y-PosY)) < float2(0.0025,0.009));DD -= all( abs(float2( texcoord.x -PosXDD-offsetDD, texcoord.y-PosY)) < float2(0.0025,0.007));
 }
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //SD video
 float LI(in float3 value)
 {
-	return dot(value.rgb,float3(0.299, 0.587, 0.114));
+    return dot(value.rgb,float3(0.299, 0.587, 0.114));
 }
 
 float4 GetBB(float2 texcoord : TEXCOORD)
 {
-	return tex2D(BackBuffer, texcoord);
+    return tex2D(BackBuffer, texcoord);
 }
 
 float4 NFAA(float2 texcoord)
-{	float t, l, r, s, MA = Mask_Adjust;
+{    float t, l, r, s, MA = Mask_Adjust;
   if(View_Mode == 3 )
     MA = 5.0;
-	float2 UV = texcoord.xy, SW = pix * MA, n; // But, I don't think it's really needed.
-	float4 NFAA; // The Edge Seeking code can be adjusted to look for longer edges.
-	// Find Edges
-	t = LI(GetBB( float2( UV.x , UV.y - SW.y ) ).rgb);
-	s = LI(GetBB( float2( UV.x , UV.y + SW.y ) ).rgb);
-	l = LI(GetBB( float2( UV.x - SW.x , UV.y ) ).rgb);
-	r = LI(GetBB( float2( UV.x + SW.x , UV.y ) ).rgb);
+    float2 UV = texcoord.xy, SW = pix * MA, n; // But, I don't think it's really needed.
+    float4 NFAA; // The Edge Seeking code can be adjusted to look for longer edges.
+    // Find Edges
+    t = LI(GetBB( float2( UV.x , UV.y - SW.y ) ).rgb);
+    s = LI(GetBB( float2( UV.x , UV.y + SW.y ) ).rgb);
+    l = LI(GetBB( float2( UV.x - SW.x , UV.y ) ).rgb);
+    r = LI(GetBB( float2( UV.x + SW.x , UV.y ) ).rgb);
     n = float2(t - s,-(r - l));
-	// I should have made rep adjustable. But, I didn't see the need.
-	// Since my goal was to make this AA fast cheap and simple.
+    // I should have made rep adjustable. But, I didn't see the need.
+    // Since my goal was to make this AA fast cheap and simple.
   float nl = length(n), Rep = rcp(AA_Adjust);
-	if(View_Mode == 3 || View_Mode == 4)
-		Rep = rcp(128);
-	// Seek aliasing and apply AA. Think of this as basically blur control.
+    if(View_Mode == 3 || View_Mode == 4)
+        Rep = rcp(128);
+    // Seek aliasing and apply AA. Think of this as basically blur control.
     if (nl < Rep)
     {
-		  NFAA = GetBB(UV);
+          NFAA = GetBB(UV);
     }
     else
     {
-		  n *= pix / (nl * (View_Mode == 3 ? 0.5 : 1.0));
+          n *= pix / (nl * (View_Mode == 3 ? 0.5 : 1.0));
 
-	float4   o = GetBB( UV ),
-			t0 = GetBB( UV + float2(n.x, -n.y)  * 0.5) * 0.9,
-			t1 = GetBB( UV - float2(n.x, -n.y)  * 0.5) * 0.9,
-			t2 = GetBB( UV + n * 0.9) * 0.75,
-			t3 = GetBB( UV - n * 0.9) * 0.75;
+    float4   o = GetBB( UV ),
+            t0 = GetBB( UV + float2(n.x, -n.y)  * 0.5) * 0.9,
+            t1 = GetBB( UV - float2(n.x, -n.y)  * 0.5) * 0.9,
+            t2 = GetBB( UV + n * 0.9) * 0.75,
+            t3 = GetBB( UV - n * 0.9) * 0.75;
 
-		NFAA = (o + t0 + t1 + t2 + t3) / 4.3;
-	}
-	// Lets make that mask for a sharper image.
-	float Mask = nl * 5.0;
-	if (Mask > 0.025)
-		Mask = 1-Mask;
-	else
-		Mask = 1;
-	// Super Evil Magic Number.
-	Mask = saturate(lerp(Mask,1,-1));
+        NFAA = (o + t0 + t1 + t2 + t3) / 4.3;
+    }
+    // Lets make that mask for a sharper image.
+    float Mask = nl * 5.0;
+    if (Mask > 0.025)
+        Mask = 1-Mask;
+    else
+        Mask = 1;
+    // Super Evil Magic Number.
+    Mask = saturate(lerp(Mask,1,-1));
 
-	// Final color
-	if(View_Mode == 0)
-	{
-		NFAA = lerp(NFAA,GetBB( texcoord.xy), Mask );
-	}
-	else if(View_Mode == 1)
-	{
-		NFAA = Mask;
-	}
-	else if (View_Mode == 2)
-	{
-		NFAA = float3(-float2(-(r - l),-(t - s)) * 0.5 + 0.5,1);
-	}
+    // Final color
+    if(View_Mode == 0)
+    {
+        NFAA = lerp(NFAA,GetBB( texcoord.xy), Mask );
+    }
+    else if(View_Mode == 1)
+    {
+        NFAA = Mask;
+    }
+    else if (View_Mode == 2)
+    {
+        NFAA = float3(-float2(-(r - l),-(t - s)) * 0.5 + 0.5,1);
+    }
 
 return NFAA;
 }
 
 void A1(float2 texcoord,float PosX,float PosY,inout float I, inout float N, inout float F, inout float O)
 {
-		float PosXI = 0.0155+PosX, PosYI = 0.004+PosY, PosYII = 0.008+PosY;I = all( abs(float2( texcoord.x - PosXI, texcoord.y - PosY)) < float2(0.003,0.001));I += all( abs(float2( texcoord.x - PosXI, texcoord.y - PosYI)) < float2(0.000625,0.005));I += all( abs(float2( texcoord.x - PosXI, texcoord.y - PosYII)) < float2(0.003,0.001));
-		float PosXN = 0.0225+PosX, PosYN = 0.005+PosY,offsetN = -0.001;N = all( abs(float2( texcoord.x - PosXN, texcoord.y - PosYN)) < float2(0.002,0.004));N -= all( abs(float2( texcoord.x - PosXN, texcoord.y - PosYN - offsetN)) < float2(0.003,0.005));
-		float PosXF = 0.029+PosX, PosYF = 0.004+PosY, offsetF = 0.0005, offsetF1 = 0.001;F = all( abs(float2( texcoord.x -PosXF-offsetF, texcoord.y-PosYF-offsetF1)) < float2(0.002,0.004));F -= all( abs(float2( texcoord.x -PosXF, texcoord.y-PosYF)) < float2(0.0025,0.005));F += all( abs(float2( texcoord.x -PosXF, texcoord.y-PosYF)) < float2(0.0015,0.00075));
-		float PosXO = 0.035+PosX, PosYO = 0.004+PosY;O = all( abs(float2( texcoord.x -PosXO, texcoord.y-PosYO)) < float2(0.003,0.005));O -= all( abs(float2( texcoord.x -PosXO, texcoord.y-PosYO)) < float2(0.002,0.003));
+        float PosXI = 0.0155+PosX, PosYI = 0.004+PosY, PosYII = 0.008+PosY;I = all( abs(float2( texcoord.x - PosXI, texcoord.y - PosY)) < float2(0.003,0.001));I += all( abs(float2( texcoord.x - PosXI, texcoord.y - PosYI)) < float2(0.000625,0.005));I += all( abs(float2( texcoord.x - PosXI, texcoord.y - PosYII)) < float2(0.003,0.001));
+        float PosXN = 0.0225+PosX, PosYN = 0.005+PosY,offsetN = -0.001;N = all( abs(float2( texcoord.x - PosXN, texcoord.y - PosYN)) < float2(0.002,0.004));N -= all( abs(float2( texcoord.x - PosXN, texcoord.y - PosYN - offsetN)) < float2(0.003,0.005));
+        float PosXF = 0.029+PosX, PosYF = 0.004+PosY, offsetF = 0.0005, offsetF1 = 0.001;F = all( abs(float2( texcoord.x -PosXF-offsetF, texcoord.y-PosYF-offsetF1)) < float2(0.002,0.004));F -= all( abs(float2( texcoord.x -PosXF, texcoord.y-PosYF)) < float2(0.0025,0.005));F += all( abs(float2( texcoord.x -PosXF, texcoord.y-PosYF)) < float2(0.0015,0.00075));
+        float PosXO = 0.035+PosX, PosYO = 0.004+PosY;O = all( abs(float2( texcoord.x -PosXO, texcoord.y-PosYO)) < float2(0.003,0.005));O -= all( abs(float2( texcoord.x -PosXO, texcoord.y-PosYO)) < float2(0.002,0.003));
 }
 
 float4 Out(float4 position : SV_Position, float2 texcoord : TEXCOORD) : SV_Target
 {   float3 Color = NFAA(texcoord).rgb;
-	float PosX = 0.9525f*BUFFER_WIDTH*pix.x,PosY = 0.975f*BUFFER_HEIGHT*pix.y,A,B,C,D,E,F,G,H,I,J,K,L,PosXDot = 0.011+PosX, PosYDot = 0.008+PosY;L = all( abs(float2( texcoord.x -PosXDot, texcoord.y-PosYDot)) < float2(0.00075,0.0015));A0(texcoord,PosX,PosY,A,B,C,D,E,F,G );A1(texcoord,PosX,PosY,H,I,J,K);
-	return timer <= 12500 ? A+B+C+D+E+F+G+H+I+J+K+L ? 1-texcoord.y*50.0+48.35f : float4(Color,1.) : float4(Color,1.);
+    float PosX = 0.9525f*BUFFER_WIDTH*pix.x,PosY = 0.975f*BUFFER_HEIGHT*pix.y,A,B,C,D,E,F,G,H,I,J,K,L,PosXDot = 0.011+PosX, PosYDot = 0.008+PosY;L = all( abs(float2( texcoord.x -PosXDot, texcoord.y-PosYDot)) < float2(0.00075,0.0015));A0(texcoord,PosX,PosY,A,B,C,D,E,F,G );A1(texcoord,PosX,PosY,H,I,J,K);
+    return timer <= 12500 ? A+B+C+D+E+F+G+H+I+J+K+L ? 1-texcoord.y*50.0+48.35f : float4(Color,1.) : float4(Color,1.);
 }
 
 float4 PostFilter(float4 position : SV_Position, float2 texcoord : TEXCOORD) : SV_Target
@@ -208,23 +208,23 @@ float4 PostFilter(float4 position : SV_Position, float2 texcoord : TEXCOORD) : S
 // Vertex shader generating a triangle covering the entire screen
 void PostProcessVS(in uint id : SV_VertexID, out float4 position : SV_Position, out float2 texcoord : TEXCOORD)
 {
-	texcoord.x = (id == 2) ? 2.0 : 0.0;
-	texcoord.y = (id == 1) ? 2.0 : 0.0;
-	position = float4(texcoord * float2(2.0, -2.0) + float2(-1.0, 1.0), 0.0, 1.0);
+    texcoord.x = (id == 2) ? 2.0 : 0.0;
+    texcoord.y = (id == 1) ? 2.0 : 0.0;
+    position = float4(texcoord * float2(2.0, -2.0) + float2(-1.0, 1.0), 0.0, 1.0);
 }
 
 //*Rendering passes*//
 technique Normal_Filter_Anti_Aliasing
 {
-			pass NFAA_Fast
-		{
-			VertexShader = PostProcessVS;
-			PixelShader = Out;
-		}
-			pass HFR_AA
-		{
-			VertexShader = PostProcessVS;
-			PixelShader = PostFilter;
-		}
+            pass NFAA_Fast
+        {
+            VertexShader = PostProcessVS;
+            PixelShader = Out;
+        }
+            pass HFR_AA
+        {
+            VertexShader = PostProcessVS;
+            PixelShader = PostFilter;
+        }
 
 }

--- a/Shaders/NFAA.fx
+++ b/Shaders/NFAA.fx
@@ -10,6 +10,8 @@
  //* Due Diligence
  //* Based on port by b34r
  //* https://www.gamedev.net/forums/topic/580517-nfaa---a-post-process-anti-aliasing-filter-results-implementation-details/?page=2
+ //* Later rewritten by Eric B. AKA Kourinn
+ //* https://github.com/BlueSkyDefender/AstrayFX/pull/17
  //* If I missed any please tell me.
  //*
  //* LICENSE
@@ -46,62 +48,73 @@
 uniform int EdgeDetectionType < __UNIFORM_COMBO_INT1
 	ui_items = "Luminance edge detection\0Perceived Luminance edge detection\0Color edge detection\0Perceived Color edge detection\0";
 	ui_label = "Edge Detection Type";
-> = 1;
+> = 3;
 
 uniform float EdgeDetectionThreshold < __UNIFORM_DRAG_FLOAT1
 	ui_label = "Edge Detection Threshold";
-    ui_tooltip = "If NFAA misses some edges try lowering this slightly.\n"
-				 "Default is 0.100";
-    ui_min = 0.000; ui_max = 0.200;
+    ui_tooltip = "The difference in Luminence/Color that would be perceived as an edge.\n" 
+				 "Try lowering this slightly if the Edge Mask misses some edges.\n"
+				 "Default is 0.063";
+    ui_min = 0.050; ui_max = 0.200; ui_step = 0.001;
 > = 0.100;
 
-uniform float SearchWidth < __UNIFORM_DRAG_FLOAT1
-    ui_label = "Search Radius";
+uniform float EdgeSearchRadius < __UNIFORM_DRAG_FLOAT1
+    ui_label = "Edge Search Radius";
     ui_tooltip = "The radius to search for edges.\n"
-				 "Try lowering this if short edges are not blurred.\n"
 				 "Try raising this if using in-game upscaling.\n"
                  "Default is 1.000";
-    ui_min = 0.500; ui_max = 4.000;
+    ui_min = 0.000; ui_max = 4.000; ui_step = 0.001;
+> = 1.000;
+
+uniform float UnblurFilterStrength < __UNIFORM_DRAG_FLOAT1
+    ui_label = "Unblur Filter Strength";
+    ui_tooltip = "Adjusts the Edge Mask and Corner Mask contrast for filtering unwanted edge blur.\n"
+				 "Try raising this if text or icons become blurry.\n"
+				 "Try lowering this if edges are still too aliased.\n"
+                 "Default is 1.000";
+    ui_min = 0.000; ui_max = 2.000; ui_step = 0.001;
 > = 1.000;
 
 uniform float BlurStrength < __UNIFORM_DRAG_FLOAT1
     ui_label = "Blur Strength";
-    ui_tooltip = "Darkens Edge Mask for filtering edge blur strength.\n"
+    ui_tooltip = "Adjusts the Normal Map weights for stronger edge blur.\n"
 				 "Try raising this if edges are still too aliased.\n"
 				 "Try lowering this if text or icons become blurry.\n"
                  "Default is 1.000";
-    ui_min = 0.000; ui_max = 2.000;
+    ui_min = 0.000; ui_max = 2.000; ui_step = 0.001;
 > = 1.000;
 
-uniform float BlurSize < __UNIFORM_DRAG_FLOAT1
+uniform float2 BlurSize < __UNIFORM_DRAG_FLOAT1
     ui_label = "Blur Size";
-    ui_tooltip = "Sets Normal Map depth for larger edge blur length.\n"
+    ui_tooltip = "Adjusts the Normal Map depth for larger/longer edge blur.\n"
+				 "Inputs are blur size parallel and perpendicular to the edge respectively.\n"
 				 "Try raising this if edges are still too aliased.\n"
 				 "Try lowering this if text or icons become blurry.\n"
-                 "Default is 1.000";
-    ui_min = 0.000; ui_max = 2.000;
-> = 1.000;
+                 "Defaults are 2.000 and 1.000";
+    ui_min = 0.000; ui_max = 4.000; ui_step = 0.001;
+> = float2(2.000, 1.000);
 
 uniform int DebugOutput < __UNIFORM_COMBO_INT1
     ui_label = "Debug Output";
-    ui_items = "None\0Edge Mask View\0Normal Map View\0";
-    ui_tooltip = "Edge Mask View gives you a view of the Edge Detection and Blur Strength.\n"
-                 "Normal Map View gives you a view of the Normal Map creation, Blur Size, and Blur Direction.";
+    ui_items = "None\0Edge Mask View\0Corner Mask View\0Normal Map View\0Pre-Blur Mask View\0Post-Blur Mask View\0";
+    ui_tooltip = "Edge Mask View shows the Edge Detection and Unblur Filter Strength.\n"
+				 "Corner Mask View shows the Corner Detection and Unblur Filter Strength.\n"
+                 "Normal Map View shows the Normal Map depth, used for Blur Size and Blur Direction.\n"
+				 "Pre-Blur Mask View shows just the edges that will be blurred.\n"
+				 "Post-Blur Mask View shows just the edges have been blurred.";
+	ui_spacing = 2;
 > = 0;
 
 ////////////////////////////////////////////////////////////Variables////////////////////////////////////////////////////////////////////
 
 // sRGB Luminance
-static const float3 LinearizeVector[4] = { float3(0.2126, 0.7152, 0.0722), float3(0.299, 0.587, 0.114), float3(1.0, 1.0, 1.0), float3(0.508, 1.0, 0.195) };
+static const float3 LinearizeVector[4] = { float3(0.2126, 0.7152, 0.0722), float3(0.299, 0.587, 0.114), float3(0.3333333, 0.3333333, 0.3333333), float3(0.299, 0.587, 0.114) };
 
-static const float cos45 = 0.70710678118654752440084436210485;
+static const float Cos45 = 0.70710678118654752440084436210485;
+
+static const float MaxSlope = 1024.0;
 
 ////////////////////////////////////////////////////////////Functions////////////////////////////////////////////////////////////////////
-
-float signF(float n) {
-	// sign intrinsic can return 0, which we don't want.
-	return n < 0.0 ? -1.0 : 1.0;
-}
 
 float LinearDifference(float3 A, float3 B)
 {
@@ -109,26 +122,21 @@ float LinearDifference(float3 A, float3 B)
 	if (EdgeDetectionType < 2)
     	return lumDiff;
 	
-	// color detection is a bit more expensive, so luminance is default
-	else if (EdgeDetectionType == 2)
-	{
-		float3 C = abs(A - B);
-		return max(max(C.r, C.g), C.b) * signF(lumDiff);
-	}
-	else { // if (EdgeDetectionType == 3)
-		float3 C = abs(A - B) * LinearizeVector[EdgeDetectionType];
-		return max(max(C.r, C.g), C.b) * signF(lumDiff);
-	}
+	float3 C = abs(A - B);
+	return max(max(C.r, C.g), C.b) * (lumDiff < 0.0 ? -1.0 : 1.0); // sign intrinsic can return 0, which we don't want. Plus this is faster.
 }
 
 float2 Rotate45(float2 p) {
-	return float2(p.x * cos45 - p.y * cos45, p.x * cos45 + p.y * cos45);
+	return float2(mad(p.x, Cos45, -p.y * Cos45), mad(p.x, Cos45, p.y * Cos45));
+	// return float2(p.x * Cos45 - p.y * Cos45, p.x * Cos45 + p.y * Cos45);
 }
 
 ////////////////////////////////////////////////////////////NFAA////////////////////////////////////////////////////////////////////
 
 float4 NFAA(float2 texcoord, float4 offsets[4])
 {
+	float4 color = tex2Dlod(ReShade::BackBuffer, float4(texcoord, 0.0, 0.0));
+
 	// Find Edges
 	//  +---+---+---+---+---+
 	//  |   |   |   |   |   |
@@ -160,49 +168,31 @@ float4 NFAA(float2 texcoord, float4 offsets[4])
 	//  |   |   |   |   |   |
 	//  +---+---+---+---+---+
 	// float angle = 0.0;
-	// float3 t = tex2Dlod(ReShade::BackBuffer, float4(mad(float2(0.0, -SearchWidth), BUFFER_PIXEL_SIZE, texcoord), 0.0, 0.0)).rgb;
-	// float3 b = tex2Dlod(ReShade::BackBuffer, float4(mad(float2(-0.0, SearchWidth), BUFFER_PIXEL_SIZE, texcoord), 0.0, 0.0)).rgb;
-	// float3 r = tex2Dlod(ReShade::BackBuffer, float4(mad(float2(SearchWidth, 0.0), BUFFER_PIXEL_SIZE, texcoord), 0.0, 0.0)).rgb;
-	// float3 l = tex2Dlod(ReShade::BackBuffer, float4(mad(float2(-SearchWidth, 0.0), BUFFER_PIXEL_SIZE, texcoord), 0.0, 0.0)).rgb;
-
-	float4 color = tex2Dlod(ReShade::BackBuffer, float4(texcoord, 0.0, 0.0));
-	
-	// Normal Depth
+	// float3 t = tex2Dlod(ReShade::BackBuffer, float4(mad(float2(0.0, -EdgeSearchRadius), BUFFER_PIXEL_SIZE, texcoord), 0.0, 0.0)).rgb;
+	// float3 b = tex2Dlod(ReShade::BackBuffer, float4(mad(float2(-0.0, EdgeSearchRadius), BUFFER_PIXEL_SIZE, texcoord), 0.0, 0.0)).rgb;
+	// float3 r = tex2Dlod(ReShade::BackBuffer, float4(mad(float2(EdgeSearchRadius, 0.0), BUFFER_PIXEL_SIZE, texcoord), 0.0, 0.0)).rgb;
+	// float3 l = tex2Dlod(ReShade::BackBuffer, float4(mad(float2(-EdgeSearchRadius, 0.0), BUFFER_PIXEL_SIZE, texcoord), 0.0, 0.0)).rgb;
 	// float2 n = float2(LinearDifference(t, b), LinearDifference(r, l));
 
-	// top vs bottom = 	a + b - c - d = 	(e + 2*f + g) / 4 - (j + 2*k + l) / 4
-	// TL vs BR = 		4/3 * (a - d) = 	(h + e + f) / 3 - (k + l + i) / 3
-	float4 n;
-	n.x = LinearDifference(b + d, a + c); // right - left
-	n.y = LinearDifference(c + d, a + b); // bottom - top
-	n.z = 1.3333333 * LinearDifference(d, a); // bottom-right - top-left
-	n.w = 1.3333333 * LinearDifference(c, b); // bottom-left - top-right
-    
-	float2 nLength = float2(length(n.xy), length(n.zw));
-	
-	float3 normalMap = float3(0.5, 0.5, 1.0);
+	// i.e. top vs bottom = a + b - (c + d) = (e + 2*f + g) / 4 - (j + 2*k + l) / 4
+	float2 normal = float2(LinearDifference(b + d, a + c), LinearDifference(c + d, a + b)); // right - left, bottom - top
+	float edge = length(normal);
+
 	float edgeMask = 1.0;
-
-	float2 normal;
-	float edge;
-	if (nLength.y > nLength.x) {
-		normal = Rotate45(n.zw);
-		edge = nLength.y;
-	}
-	else {
-		normal = n.xy;
-		edge = nLength.x;
-	}
-
-    if (edge >= EdgeDetectionThreshold)
+	float cornerMask = 1.0;
+    if (edge > EdgeDetectionThreshold)
 	{
 		// Lets make that edgeMask for a sharper image.
-		// Mask Formula: 1.0 - 5.0 * edge.
-		edgeMask = saturate(mad(edge, -5.0 * BlurStrength, 1.0));
-		// Normal map, right = red, green = top
-		normalMap.rg = mad(float2(-normal.r, normal.g) * BlurSize, 0.5, 0.5);
+		float edgeConfidence = log2(edge / EdgeDetectionThreshold);
+		edgeMask = saturate(mad(edgeConfidence, UnblurFilterStrength - 2.0, 1.0));
+		// edgeMask = saturate((1.0 - (UnblurFilterStrength - 2.0) * edgeConfidence);
 
-		// calculate x/y coordinates on the line at specified distances and offsets
+		// Then subtract corners from edge mask to avoid bluring text and detailed icons
+		float4 corners = float4(LinearDifference(a + b + c, 3.0 * d), LinearDifference(a + b + d, 3.0 * c), LinearDifference(a + c + d, 3.0 * b), LinearDifference(c + d + b, 3.0 * a));
+		float corner = dot(abs(corners), 0.25);
+		cornerMask = saturate(edgeMask + corner);
+
+		// calculate x/y coordinates along the edge at specified distances and offsets
 		// +---+---+---+---+---+ +---+---+---+---+---+
 		// |   |   |   |   |   | |   |   |   |   |   |
 		// +---+---+---+---+---+ +---+---+---+---+---+
@@ -216,18 +206,22 @@ float4 NFAA(float2 texcoord, float4 offsets[4])
 		// +---+---+---+---+---+ +---+---+---+---+---+
 
 		// slope m = normal.r / normal.g
-		// distance d = 1
+		// distance d
 		// y = mx
 		// d^2 = y^2 + x^2 = (mx)^2+x^2
 		// d^2 = x^2(1 + m^2)
 		// x^2 = d^2/(1 + m^2)
 
+		// Follow the edge for 1/2 of BlurSize.x
 		float4 offset;
-		float m = normal.g != 0 ? normal.r / normal.g : 1024.0;
-		offset.x = sqrt(BlurSize * BlurSize / (1.0 + m * m));
+		float m = normal.g != 0 ? normal.r / normal.g : MaxSlope;
+		float d = 0.5 * BlurSize.x;
+		offset.x = sqrt(d *d / (1.0 + m * m));
 		offset.y = m * offset.x;
-		m = normal.r != 0 ? -normal.g / normal.r : 1024.0;
-		offset.z = sqrt(0.25 * BlurSize * BlurSize / (1.0 + m * m));
+		// Then move perpendicular to the edge for 1/2 of BlurSize.y
+		m = normal.r != 0 ? -normal.g / normal.r : MaxSlope;
+		d = 0.5 * BlurSize.y;
+		offset.z = sqrt(d * d / (1.0 + m * m));
 		offset.w = m * offset.z;
 
         float3 e = tex2Dlod(ReShade::BackBuffer, float4(mad(offset.xy + offset.zw, BUFFER_PIXEL_SIZE, texcoord), 0.0, 0.0)).rgb;
@@ -235,13 +229,19 @@ float4 NFAA(float2 texcoord, float4 offsets[4])
         float3 g = tex2Dlod(ReShade::BackBuffer, float4(mad(-offset.xy + offset.zw, BUFFER_PIXEL_SIZE, texcoord), 0.0, 0.0)).rgb;
 		float3 h = tex2Dlod(ReShade::BackBuffer, float4(mad(-offset.xy - offset.zw, BUFFER_PIXEL_SIZE, texcoord), 0.0, 0.0)).rgb;
 
-		// possible to reduce taps by re-using edge detection taps a, b, c, d
-		// but its not worth it, nearby pixels should already be cached, and needs more math
+		// It's possible to reduce taps by re-using edge detection taps a, b, c, d,
+		// but it's not worth it. Nearby pixels should already be cached, and it would need more math.
 
-		color.rgb = lerp(mad(e + f + g + h, 0.125 * BlurStrength, color.rgb * 0.5 * (2.0 - BlurStrength)), color.rgb, edgeMask);
+		// apply blur
+		if (DebugOutput != 4)
+			color.rgb = lerp(color.rgb, (e + f + g + h) * 0.25, BlurStrength * 0.5 * (1.0 - cornerMask));
+		
+		// Pre/Post Blur Mask
+		if (DebugOutput > 3)
+			color.a = cornerMask;
 
 		// original blur from b34r & BlueSkyDefender
-		// may need some work to be functional again due to some variable name refactoring I reversed how/why it worked - Eric B.
+		// may need some work to be functional again due to some variable name refactoring I reversed how/why it worked
 		// +---+---+---+---+---+
 		// |   |   |   |   |   |
 		// +---+---+---+---+---+
@@ -263,26 +263,69 @@ float4 NFAA(float2 texcoord, float4 offsets[4])
 		// float4 t3 = tex2Dlod(ReShade::BackBuffer, float4(mad(float2(-dn.x, dn.y) * 0.9, BUFFER_PIXEL_SIZE, texcoord), 0.0, 0.0));
 		// color = lerp(mad(color, 0.23, 0.175 * (t2 + t3) + 0.21 * (t0 + t1)), color, edgeMask);
     }
+	else {
+		color.a = 0.0;
+	}
 
-    if(DebugOutput == 1)
+    if(DebugOutput == 1) // Edge Mask
     {
         color.rgb = edgeMask;
     }
-    else if (DebugOutput == 2)
+	if(DebugOutput == 2) // Corner Mask
     {
+        color.rgb = cornerMask;
+    }
+    else if (DebugOutput == 3) // Normal Map
+    {
+		// Normal map, right = red, green = top, configured using white box with black background
+		float3 normalMap;
+		normalMap.b = 1.0;
+		normalMap.rg = mad(float2(-normal.r, normal.g) * BlurSize.x * BlurStrength, 0.25, 0.5);
+		normalMap.rg = lerp(float2(0.5, 0.5), saturate(normalMap.rg), (1.0 - edgeMask) * BlurSize.y);
         color.rgb = normalMap;
     }
+	else if (DebugOutput > 3) { // Pre/Post Blur Mask
+		uint row = floor(texcoord.y / 0.1);
+        uint col = floor(texcoord.x * BUFFER_ASPECT_RATIO / 0.1);
 
+		float3 lightGray = 0.5;
+		float3 darkGray = 0.1667;
+		
+		lightGray = lerp(lightGray, color.rgb, color.a);
+		darkGray = lerp(darkGray, color.rgb, color.a);
+
+		// Create checkerboad background to depict transparency
+        if (row % 2 == 0) {
+            if (col % 2 == 0) {
+                color.rgb = lightGray;
+            }
+            else {
+                color.rgb = darkGray;
+            }
+        }
+        else {
+            if (col % 2 == 0) {
+                color.rgb = darkGray;
+            }
+            else {
+                color.rgb = lightGray;
+            }
+        }
+		
+	}
+
+	color.a = 1.0;
 	return color;
 }
 
 void NFAA_VS(in uint id : SV_VertexID, out float4 position : SV_POSITION, out float2 texcoord : TEXCOORD, out float4 offsets[4] : OFFSETS )
 {
     PostProcessVS(id, position, texcoord);
-	offsets[0] = float4(mad(float2(-1.0, -1.0) * BUFFER_PIXEL_SIZE, SearchWidth, texcoord), 0.0, 0.0);
-	offsets[1] = float4(mad(float2(1.0, -1.0) * BUFFER_PIXEL_SIZE, SearchWidth, texcoord), 0.0, 0.0);
-	offsets[2] = float4(mad(float2(-1.0, 1.0) * BUFFER_PIXEL_SIZE, SearchWidth, texcoord), 0.0, 0.0);
-	offsets[3] = float4(mad(float2(1.0, 1.0) * BUFFER_PIXEL_SIZE, SearchWidth, texcoord), 0.0, 0.0);
+	float2 offset =  Cos45 * EdgeSearchRadius * BUFFER_PIXEL_SIZE;
+	offsets[0] = float4(mad(float2(-1.0, -1.0), offset, texcoord), 0.0, 0.0);
+	offsets[1] = float4(mad(float2(1.0, -1.0),  offset, texcoord), 0.0, 0.0);
+	offsets[2] = float4(mad(float2(-1.0, 1.0), offset, texcoord), 0.0, 0.0);
+	offsets[3] = float4(mad(float2(1.0, 1.0), offset, texcoord), 0.0, 0.0);
 }
 
 float4 NFAA_PS(in float4 position : SV_Position, in float2 texcoord : TEXCOORD, in float4 offsets[4] : OFFSETS) : SV_Target

--- a/Shaders/NFAA.fx
+++ b/Shaders/NFAA.fx
@@ -46,22 +46,22 @@
 #include "ReShade.fxh"
 
 uniform int EdgeDetectionType < __UNIFORM_COMBO_INT1
-	ui_items = "Luminance edge detection\0Perceived Luminance edge detection\0Color edge detection\0Perceived Color edge detection\0";
-	ui_label = "Edge Detection Type";
+    ui_items = "Luminance edge detection\0Perceived Luminance edge detection\0Color edge detection\0Perceived Color edge detection\0";
+    ui_label = "Edge Detection Type";
 > = 3;
 
 uniform float EdgeDetectionThreshold < __UNIFORM_DRAG_FLOAT1
-	ui_label = "Edge Detection Threshold";
+    ui_label = "Edge Detection Threshold";
     ui_tooltip = "The difference in Luminence/Color that would be perceived as an edge.\n" 
-				 "Try lowering this slightly if the Edge Mask misses some edges.\n"
-				 "Default is 0.063";
+                 "Try lowering this slightly if the Edge Mask misses some edges.\n"
+                 "Default is 0.063";
     ui_min = 0.050; ui_max = 0.200; ui_step = 0.001;
 > = 0.100;
 
 uniform float EdgeSearchRadius < __UNIFORM_DRAG_FLOAT1
     ui_label = "Edge Search Radius";
     ui_tooltip = "The radius to search for edges.\n"
-				 "Try raising this if using in-game upscaling.\n"
+                 "Try raising this if using in-game upscaling.\n"
                  "Default is 1.000";
     ui_min = 0.000; ui_max = 4.000; ui_step = 0.001;
 > = 1.000;
@@ -69,8 +69,8 @@ uniform float EdgeSearchRadius < __UNIFORM_DRAG_FLOAT1
 uniform float UnblurFilterStrength < __UNIFORM_DRAG_FLOAT1
     ui_label = "Unblur Filter Strength";
     ui_tooltip = "Adjusts the Edge Mask and Corner Mask contrast for filtering unwanted edge blur.\n"
-				 "Try raising this if text or icons become blurry.\n"
-				 "Try lowering this if edges are still too aliased.\n"
+                 "Try raising this if text or icons become blurry.\n"
+                 "Try lowering this if edges are still too aliased.\n"
                  "Default is 1.000";
     ui_min = 0.000; ui_max = 2.000; ui_step = 0.001;
 > = 1.000;
@@ -78,8 +78,8 @@ uniform float UnblurFilterStrength < __UNIFORM_DRAG_FLOAT1
 uniform float BlurStrength < __UNIFORM_DRAG_FLOAT1
     ui_label = "Blur Strength";
     ui_tooltip = "Adjusts the Normal Map weights for stronger edge blur.\n"
-				 "Try raising this if edges are still too aliased.\n"
-				 "Try lowering this if text or icons become blurry.\n"
+                 "Try raising this if edges are still too aliased.\n"
+                 "Try lowering this if text or icons become blurry.\n"
                  "Default is 1.000";
     ui_min = 0.000; ui_max = 2.000; ui_step = 0.001;
 > = 1.000;
@@ -87,9 +87,9 @@ uniform float BlurStrength < __UNIFORM_DRAG_FLOAT1
 uniform float2 BlurSize < __UNIFORM_DRAG_FLOAT1
     ui_label = "Blur Size";
     ui_tooltip = "Adjusts the Normal Map depth for larger/longer edge blur.\n"
-				 "Inputs are blur size parallel and perpendicular to the edge respectively.\n"
-				 "Try raising this if edges are still too aliased.\n"
-				 "Try lowering this if text or icons become blurry.\n"
+                 "Inputs are blur size parallel and perpendicular to the edge respectively.\n"
+                 "Try raising this if edges are still too aliased.\n"
+                 "Try lowering this if text or icons become blurry.\n"
                  "Defaults are 2.000 and 1.000";
     ui_min = 0.000; ui_max = 4.000; ui_step = 0.001;
 > = float2(2.000, 1.000);
@@ -98,11 +98,11 @@ uniform int DebugOutput < __UNIFORM_COMBO_INT1
     ui_label = "Debug Output";
     ui_items = "None\0Edge Mask View\0Corner Mask View\0Normal Map View\0Pre-Blur Mask View\0Post-Blur Mask View\0";
     ui_tooltip = "Edge Mask View shows the Edge Detection and Unblur Filter Strength.\n"
-				 "Corner Mask View shows the Corner Detection and Unblur Filter Strength.\n"
+                 "Corner Mask View shows the Corner Detection and Unblur Filter Strength.\n"
                  "Normal Map View shows the Normal Map depth, used for Blur Size and Blur Direction.\n"
-				 "Pre-Blur Mask View shows just the edges that will be blurred.\n"
-				 "Post-Blur Mask View shows just the edges have been blurred.";
-	ui_spacing = 2;
+                 "Pre-Blur Mask View shows just the edges that will be blurred.\n"
+                 "Post-Blur Mask View shows just the edges have been blurred.";
+    ui_spacing = 2;
 > = 0;
 
 ////////////////////////////////////////////////////////////Variables////////////////////////////////////////////////////////////////////
@@ -118,183 +118,183 @@ static const float MaxSlope = 1024.0;
 
 float LinearDifference(float3 A, float3 B)
 {
-	float lumDiff = dot(A, LinearizeVector[EdgeDetectionType]) - dot(B, LinearizeVector[EdgeDetectionType]);
-	if (EdgeDetectionType < 2)
-    	return lumDiff;
-	
-	float3 C = abs(A - B);
-	return max(max(C.r, C.g), C.b) * (lumDiff < 0.0 ? -1.0 : 1.0); // sign intrinsic can return 0, which we don't want. Plus this is faster.
+    float lumDiff = dot(A, LinearizeVector[EdgeDetectionType]) - dot(B, LinearizeVector[EdgeDetectionType]);
+    if (EdgeDetectionType < 2)
+        return lumDiff;
+    
+    float3 C = abs(A - B);
+    return max(max(C.r, C.g), C.b) * (lumDiff < 0.0 ? -1.0 : 1.0); // sign intrinsic can return 0, which we don't want. Plus this is faster.
 }
 
 float2 Rotate45(float2 p) {
-	return float2(mad(p.x, Cos45, -p.y * Cos45), mad(p.x, Cos45, p.y * Cos45));
-	// return float2(p.x * Cos45 - p.y * Cos45, p.x * Cos45 + p.y * Cos45);
+    return float2(mad(p.x, Cos45, -p.y * Cos45), mad(p.x, Cos45, p.y * Cos45));
+    // return float2(p.x * Cos45 - p.y * Cos45, p.x * Cos45 + p.y * Cos45);
 }
 
 ////////////////////////////////////////////////////////////NFAA////////////////////////////////////////////////////////////////////
 
 float4 NFAA(float2 texcoord, float4 offsets[4])
 {
-	float4 color = tex2Dlod(ReShade::BackBuffer, float4(texcoord, 0.0, 0.0));
+    float4 color = tex2Dlod(ReShade::BackBuffer, float4(texcoord, 0.0, 0.0));
 
-	// Find Edges
-	//  +---+---+---+---+---+
-	//  |   |   |   |   |   |
-	//  +---+---+---+---+---+
-	//  |   | e | f | g |   |
-	//  +---+--(a)-(b)--+---+
-	//  |   | h | P | i |   |
-	//  +---+--(c)-(d)--+---+
-	//  |   | j | k | l |   |
-	//  +---+---+---+---+---+
-	//  |   |   |   |   |   |
-	//  +---+---+---+---+---+
-	// Much better at horizontal/vertical lines, slightly better diagonals, always compares 6 pixels, not 2.
-	float3 a = tex2Dlod(ReShade::BackBuffer, offsets[0]).rgb;
-	float3 b = tex2Dlod(ReShade::BackBuffer, offsets[1]).rgb;
-	float3 c = tex2Dlod(ReShade::BackBuffer, offsets[2]).rgb;
-	float3 d = tex2Dlod(ReShade::BackBuffer, offsets[3]).rgb;
+    // Find Edges
+    //  +---+---+---+---+---+
+    //  |   |   |   |   |   |
+    //  +---+---+---+---+---+
+    //  |   | e | f | g |   |
+    //  +---+--(a)-(b)--+---+
+    //  |   | h | P | i |   |
+    //  +---+--(c)-(d)--+---+
+    //  |   | j | k | l |   |
+    //  +---+---+---+---+---+
+    //  |   |   |   |   |   |
+    //  +---+---+---+---+---+
+    // Much better at horizontal/vertical lines, slightly better diagonals, always compares 6 pixels, not 2.
+    float3 a = tex2Dlod(ReShade::BackBuffer, offsets[0]).rgb;
+    float3 b = tex2Dlod(ReShade::BackBuffer, offsets[1]).rgb;
+    float3 c = tex2Dlod(ReShade::BackBuffer, offsets[2]).rgb;
+    float3 d = tex2Dlod(ReShade::BackBuffer, offsets[3]).rgb;
 
-	// Original edge detection from b34r & BlueSkyDefender
-	//  +---+---+---+---+---+
-	//  |   |   |   |   |   |
-	//  +---+---+---+---+---+
-	//  |   |   | t |   |   |
-	//  +---+---+---+---+---+
-	//  |   | l | C | r |   |
-	//  +---+---+---+---+---+
-	//  |   |   | b |   |   |
-	//  +---+---+---+---+---+
-	//  |   |   |   |   |   |
-	//  +---+---+---+---+---+
-	// float angle = 0.0;
-	// float3 t = tex2Dlod(ReShade::BackBuffer, float4(mad(float2(0.0, -EdgeSearchRadius), BUFFER_PIXEL_SIZE, texcoord), 0.0, 0.0)).rgb;
-	// float3 b = tex2Dlod(ReShade::BackBuffer, float4(mad(float2(-0.0, EdgeSearchRadius), BUFFER_PIXEL_SIZE, texcoord), 0.0, 0.0)).rgb;
-	// float3 r = tex2Dlod(ReShade::BackBuffer, float4(mad(float2(EdgeSearchRadius, 0.0), BUFFER_PIXEL_SIZE, texcoord), 0.0, 0.0)).rgb;
-	// float3 l = tex2Dlod(ReShade::BackBuffer, float4(mad(float2(-EdgeSearchRadius, 0.0), BUFFER_PIXEL_SIZE, texcoord), 0.0, 0.0)).rgb;
-	// float2 n = float2(LinearDifference(t, b), LinearDifference(r, l));
+    // Original edge detection from b34r & BlueSkyDefender
+    //  +---+---+---+---+---+
+    //  |   |   |   |   |   |
+    //  +---+---+---+---+---+
+    //  |   |   | t |   |   |
+    //  +---+---+---+---+---+
+    //  |   | l | C | r |   |
+    //  +---+---+---+---+---+
+    //  |   |   | b |   |   |
+    //  +---+---+---+---+---+
+    //  |   |   |   |   |   |
+    //  +---+---+---+---+---+
+    // float angle = 0.0;
+    // float3 t = tex2Dlod(ReShade::BackBuffer, float4(mad(float2(0.0, -EdgeSearchRadius), BUFFER_PIXEL_SIZE, texcoord), 0.0, 0.0)).rgb;
+    // float3 b = tex2Dlod(ReShade::BackBuffer, float4(mad(float2(-0.0, EdgeSearchRadius), BUFFER_PIXEL_SIZE, texcoord), 0.0, 0.0)).rgb;
+    // float3 r = tex2Dlod(ReShade::BackBuffer, float4(mad(float2(EdgeSearchRadius, 0.0), BUFFER_PIXEL_SIZE, texcoord), 0.0, 0.0)).rgb;
+    // float3 l = tex2Dlod(ReShade::BackBuffer, float4(mad(float2(-EdgeSearchRadius, 0.0), BUFFER_PIXEL_SIZE, texcoord), 0.0, 0.0)).rgb;
+    // float2 n = float2(LinearDifference(t, b), LinearDifference(r, l));
 
-	// i.e. top vs bottom = a + b - (c + d) = (e + 2*f + g) / 4 - (j + 2*k + l) / 4
-	float2 normal = float2(LinearDifference(b + d, a + c), LinearDifference(c + d, a + b)); // right - left, bottom - top
-	float edge = length(normal);
+    // i.e. top vs bottom = a + b - (c + d) = (e + 2*f + g) / 4 - (j + 2*k + l) / 4
+    float2 normal = float2(LinearDifference(b + d, a + c), LinearDifference(c + d, a + b)); // right - left, bottom - top
+    float edge = length(normal);
 
-	float edgeMask = 1.0;
-	float cornerMask = 1.0;
+    float edgeMask = 1.0;
+    float cornerMask = 1.0;
     if (edge > EdgeDetectionThreshold)
-	{
-		// Lets make that edgeMask for a sharper image.
-		float edgeConfidence = log2(edge / EdgeDetectionThreshold);
-		edgeMask = saturate(mad(edgeConfidence, UnblurFilterStrength - 2.0, 1.0));
-		// edgeMask = saturate((1.0 - (UnblurFilterStrength - 2.0) * edgeConfidence);
+    {
+        // Lets make that edgeMask for a sharper image.
+        float edgeConfidence = log2(edge / EdgeDetectionThreshold);
+        edgeMask = saturate(mad(edgeConfidence, UnblurFilterStrength - 2.0, 1.0));
+        // edgeMask = saturate((1.0 - (UnblurFilterStrength - 2.0) * edgeConfidence);
 
-		// Then subtract corners from edge mask to avoid bluring text and detailed icons
-		float4 corners = float4(LinearDifference(a + b + c, 3.0 * d), LinearDifference(a + b + d, 3.0 * c), LinearDifference(a + c + d, 3.0 * b), LinearDifference(c + d + b, 3.0 * a));
-		float corner = dot(abs(corners), 0.25);
-		cornerMask = saturate(edgeMask + corner);
+        // Then subtract corners from edge mask to avoid bluring text and detailed icons
+        float4 corners = float4(LinearDifference(a + b + c, 3.0 * d), LinearDifference(a + b + d, 3.0 * c), LinearDifference(a + c + d, 3.0 * b), LinearDifference(c + d + b, 3.0 * a));
+        float corner = dot(abs(corners), 0.25);
+        cornerMask = saturate(edgeMask + corner);
 
-		// calculate x/y coordinates along the edge at specified distances and offsets
-		// +---+---+---+---+---+ +---+---+---+---+---+
-		// |   |   |   |   |   | |   |   |   |   |   |
-		// +---+---+---+---+---+ +---+---+---+---+---+
-		// |   |   |   |   |   | |   |   | (e)   |   |
-		// +---+(g)a---b(e)+---+ +---+---a---b(f)+---+
-		// |   |-O | P | O |   | |   |   | P |   |   |
-		// +---+(h)c---d(f)+---+ +---+(g)c---d---+---+
-		// |   |   |   |   |   | |   |   (h) |   |   |
-		// +---+---+---+---+---+ +---+---+---+---+---+
-		// |   |   |   |   |   | |   |   |   |   |   |
-		// +---+---+---+---+---+ +---+---+---+---+---+
+        // calculate x/y coordinates along the edge at specified distances and offsets
+        // +---+---+---+---+---+ +---+---+---+---+---+
+        // |   |   |   |   |   | |   |   |   |   |   |
+        // +---+---+---+---+---+ +---+---+---+---+---+
+        // |   |   |   |   |   | |   |   | (e)   |   |
+        // +---+(g)a---b(e)+---+ +---+---a---b(f)+---+
+        // |   |-O | P | O |   | |   |   | P |   |   |
+        // +---+(h)c---d(f)+---+ +---+(g)c---d---+---+
+        // |   |   |   |   |   | |   |   (h) |   |   |
+        // +---+---+---+---+---+ +---+---+---+---+---+
+        // |   |   |   |   |   | |   |   |   |   |   |
+        // +---+---+---+---+---+ +---+---+---+---+---+
 
-		// slope m = normal.r / normal.g
-		// distance d
-		// y = mx
-		// d^2 = y^2 + x^2 = (mx)^2+x^2
-		// d^2 = x^2(1 + m^2)
-		// x^2 = d^2/(1 + m^2)
+        // slope m = normal.r / normal.g
+        // distance d
+        // y = mx
+        // d^2 = y^2 + x^2 = (mx)^2+x^2
+        // d^2 = x^2(1 + m^2)
+        // x^2 = d^2/(1 + m^2)
 
-		// Follow the edge for 1/2 of BlurSize.x
-		float4 offset;
-		float m = normal.g != 0 ? normal.r / normal.g : MaxSlope;
-		float d = 0.5 * BlurSize.x;
-		offset.x = sqrt(d *d / (1.0 + m * m));
-		offset.y = m * offset.x;
-		// Then move perpendicular to the edge for 1/2 of BlurSize.y
-		m = normal.r != 0 ? -normal.g / normal.r : MaxSlope;
-		d = 0.5 * BlurSize.y;
-		offset.z = sqrt(d * d / (1.0 + m * m));
-		offset.w = m * offset.z;
+        // Follow the edge for 1/2 of BlurSize.x
+        float4 offset;
+        float m = normal.g != 0 ? normal.r / normal.g : MaxSlope;
+        float d = 0.5 * BlurSize.x;
+        offset.x = sqrt(d *d / (1.0 + m * m));
+        offset.y = m * offset.x;
+        // Then move perpendicular to the edge for 1/2 of BlurSize.y
+        m = normal.r != 0 ? -normal.g / normal.r : MaxSlope;
+        d = 0.5 * BlurSize.y;
+        offset.z = sqrt(d * d / (1.0 + m * m));
+        offset.w = m * offset.z;
 
         float3 e = tex2Dlod(ReShade::BackBuffer, float4(mad(offset.xy + offset.zw, BUFFER_PIXEL_SIZE, texcoord), 0.0, 0.0)).rgb;
         float3 f = tex2Dlod(ReShade::BackBuffer, float4(mad(offset.xy - offset.zw, BUFFER_PIXEL_SIZE, texcoord), 0.0, 0.0)).rgb;
         float3 g = tex2Dlod(ReShade::BackBuffer, float4(mad(-offset.xy + offset.zw, BUFFER_PIXEL_SIZE, texcoord), 0.0, 0.0)).rgb;
-		float3 h = tex2Dlod(ReShade::BackBuffer, float4(mad(-offset.xy - offset.zw, BUFFER_PIXEL_SIZE, texcoord), 0.0, 0.0)).rgb;
+        float3 h = tex2Dlod(ReShade::BackBuffer, float4(mad(-offset.xy - offset.zw, BUFFER_PIXEL_SIZE, texcoord), 0.0, 0.0)).rgb;
 
-		// It's possible to reduce taps by re-using edge detection taps a, b, c, d,
-		// but it's not worth it. Nearby pixels should already be cached, and it would need more math.
+        // It's possible to reduce taps by re-using edge detection taps a, b, c, d,
+        // but it's not worth it. Nearby pixels should already be cached, and it would need more math.
 
-		// apply blur
-		if (DebugOutput != 4)
-			color.rgb = lerp(color.rgb, (e + f + g + h) * 0.25, BlurStrength * 0.5 * (1.0 - cornerMask));
-		
-		// Pre/Post Blur Mask
-		if (DebugOutput > 3)
-			color.a = cornerMask;
+        // apply blur
+        if (DebugOutput != 4)
+            color.rgb = lerp(color.rgb, (e + f + g + h) * 0.25, BlurStrength * 0.5 * (1.0 - cornerMask));
+        
+        // Pre/Post Blur Mask
+        if (DebugOutput > 3)
+            color.a = cornerMask;
 
-		// original blur from b34r & BlueSkyDefender
-		// may need some work to be functional again due to some variable name refactoring I reversed how/why it worked
-		// +---+---+---+---+---+
-		// |   |   |   |   |   |
-		// +---+---+---+---+---+
-		// |\\\|   | x | x |   |
-		// +---+---+---+---+---+
-		// |   |\\\|\\\| x |   |
-		// +---+---+---+---+---+
-		// |   |   | x |\\\|\\\|
-		// +---+---+---+---+---+
-		// |   |   |   |   |   |
-		// +---+---+---+---+---+
-		// y = -0.5x; n.x = 1; n.y = 0.5; nl = 1.18; dn.x = 0.85; dn.y = 0.42;
-		// t0/1 = 0.425, 0.21; d ~= 0.5
-		// t2/3 = 0.765, -0.38; d ~= 0.85
-		// float2 dn = n / nl * BlurSize;
-		// float4 t0 = tex2Dlod(ReShade::BackBuffer, float4(mad(-dn * 0.5, BUFFER_PIXEL_SIZE, texcoord), 0.0, 0.0));
-		// float4 t1 = tex2Dlod(ReShade::BackBuffer, float4(mad(dn * 0.5, BUFFER_PIXEL_SIZE, texcoord), 0.0, 0.0));
-		// float4 t2 = tex2Dlod(ReShade::BackBuffer, float4(mad(float2(dn.x, -dn.y) * 0.9, BUFFER_PIXEL_SIZE, texcoord), 0.0, 0.0));
-		// float4 t3 = tex2Dlod(ReShade::BackBuffer, float4(mad(float2(-dn.x, dn.y) * 0.9, BUFFER_PIXEL_SIZE, texcoord), 0.0, 0.0));
-		// color = lerp(mad(color, 0.23, 0.175 * (t2 + t3) + 0.21 * (t0 + t1)), color, edgeMask);
+        // original blur from b34r & BlueSkyDefender
+        // may need some work to be functional again due to some variable name refactoring I reversed how/why it worked
+        // +---+---+---+---+---+
+        // |   |   |   |   |   |
+        // +---+---+---+---+---+
+        // |\\\|   | x | x |   |
+        // +---+---+---+---+---+
+        // |   |\\\|\\\| x |   |
+        // +---+---+---+---+---+
+        // |   |   | x |\\\|\\\|
+        // +---+---+---+---+---+
+        // |   |   |   |   |   |
+        // +---+---+---+---+---+
+        // y = -0.5x; n.x = 1; n.y = 0.5; nl = 1.18; dn.x = 0.85; dn.y = 0.42;
+        // t0/1 = 0.425, 0.21; d ~= 0.5
+        // t2/3 = 0.765, -0.38; d ~= 0.85
+        // float2 dn = n / nl * BlurSize;
+        // float4 t0 = tex2Dlod(ReShade::BackBuffer, float4(mad(-dn * 0.5, BUFFER_PIXEL_SIZE, texcoord), 0.0, 0.0));
+        // float4 t1 = tex2Dlod(ReShade::BackBuffer, float4(mad(dn * 0.5, BUFFER_PIXEL_SIZE, texcoord), 0.0, 0.0));
+        // float4 t2 = tex2Dlod(ReShade::BackBuffer, float4(mad(float2(dn.x, -dn.y) * 0.9, BUFFER_PIXEL_SIZE, texcoord), 0.0, 0.0));
+        // float4 t3 = tex2Dlod(ReShade::BackBuffer, float4(mad(float2(-dn.x, dn.y) * 0.9, BUFFER_PIXEL_SIZE, texcoord), 0.0, 0.0));
+        // color = lerp(mad(color, 0.23, 0.175 * (t2 + t3) + 0.21 * (t0 + t1)), color, edgeMask);
     }
-	else {
-		color.a = 0.0;
-	}
+    else {
+        color.a = 0.0;
+    }
 
     if(DebugOutput == 1) // Edge Mask
     {
         color.rgb = edgeMask;
     }
-	if(DebugOutput == 2) // Corner Mask
+    if(DebugOutput == 2) // Corner Mask
     {
         color.rgb = cornerMask;
     }
     else if (DebugOutput == 3) // Normal Map
     {
-		// Normal map, right = red, green = top, configured using white box with black background
-		float3 normalMap;
-		normalMap.b = 1.0;
-		normalMap.rg = mad(float2(-normal.r, normal.g) * BlurSize.x * BlurStrength, 0.25, 0.5);
-		normalMap.rg = lerp(float2(0.5, 0.5), saturate(normalMap.rg), (1.0 - edgeMask) * BlurSize.y);
+        // Normal map, right = red, green = top, configured using white box with black background
+        float3 normalMap;
+        normalMap.b = 1.0;
+        normalMap.rg = mad(float2(-normal.r, normal.g) * BlurSize.x * BlurStrength, 0.25, 0.5);
+        normalMap.rg = lerp(float2(0.5, 0.5), saturate(normalMap.rg), (1.0 - edgeMask) * BlurSize.y);
         color.rgb = normalMap;
     }
-	else if (DebugOutput > 3) { // Pre/Post Blur Mask
-		uint row = floor(texcoord.y / 0.1);
+    else if (DebugOutput > 3) { // Pre/Post Blur Mask
+        uint row = floor(texcoord.y / 0.1);
         uint col = floor(texcoord.x * BUFFER_ASPECT_RATIO / 0.1);
 
-		float3 lightGray = 0.5;
-		float3 darkGray = 0.1667;
-		
-		lightGray = lerp(lightGray, color.rgb, color.a);
-		darkGray = lerp(darkGray, color.rgb, color.a);
+        float3 lightGray = 0.5;
+        float3 darkGray = 0.1667;
+        
+        lightGray = lerp(lightGray, color.rgb, color.a);
+        darkGray = lerp(darkGray, color.rgb, color.a);
 
-		// Create checkerboad background to depict transparency
+        // Create checkerboad background to depict transparency
         if (row % 2 == 0) {
             if (col % 2 == 0) {
                 color.rgb = lightGray;
@@ -311,31 +311,31 @@ float4 NFAA(float2 texcoord, float4 offsets[4])
                 color.rgb = lightGray;
             }
         }
-		
-	}
+        
+    }
 
-	color.a = 1.0;
-	return color;
+    color.a = 1.0;
+    return color;
 }
 
 void NFAA_VS(in uint id : SV_VertexID, out float4 position : SV_POSITION, out float2 texcoord : TEXCOORD, out float4 offsets[4] : OFFSETS )
 {
     PostProcessVS(id, position, texcoord);
-	float2 offset =  Cos45 * EdgeSearchRadius * BUFFER_PIXEL_SIZE;
-	offsets[0] = float4(mad(float2(-1.0, -1.0), offset, texcoord), 0.0, 0.0);
-	offsets[1] = float4(mad(float2(1.0, -1.0),  offset, texcoord), 0.0, 0.0);
-	offsets[2] = float4(mad(float2(-1.0, 1.0), offset, texcoord), 0.0, 0.0);
-	offsets[3] = float4(mad(float2(1.0, 1.0), offset, texcoord), 0.0, 0.0);
+    float2 offset =  Cos45 * EdgeSearchRadius * BUFFER_PIXEL_SIZE;
+    offsets[0] = float4(mad(float2(-1.0, -1.0), offset, texcoord), 0.0, 0.0);
+    offsets[1] = float4(mad(float2(1.0, -1.0),  offset, texcoord), 0.0, 0.0);
+    offsets[2] = float4(mad(float2(-1.0, 1.0), offset, texcoord), 0.0, 0.0);
+    offsets[3] = float4(mad(float2(1.0, 1.0), offset, texcoord), 0.0, 0.0);
 }
 
 float4 NFAA_PS(in float4 position : SV_Position, in float2 texcoord : TEXCOORD, in float4 offsets[4] : OFFSETS) : SV_Target
 {
-	return NFAA(texcoord, offsets);
+    return NFAA(texcoord, offsets);
 }
 
 technique NFAA
 {
-		pass NFAA_Fast
+        pass NFAA_Fast
         {
             VertexShader = NFAA_VS;
             PixelShader = NFAA_PS;

--- a/Shaders/NFAA.fx
+++ b/Shaders/NFAA.fx
@@ -87,7 +87,6 @@ uniform float HFR_Adjust <
 
 //Total amount of frames since the game started.
 uniform uint framecount < source = "framecount"; >;
-uniform float timer < source = "timer"; >;
 ////////////////////////////////////////////////////////////NFAA////////////////////////////////////////////////////////////////////
 #define Alternate framecount % 2 == 0
 #define pix float2(BUFFER_RCP_WIDTH, BUFFER_RCP_HEIGHT)
@@ -98,17 +97,6 @@ sampler BackBuffer
     {
         Texture = BackBufferTex;
     };
-
-void A0(float2 texcoord,float PosX,float PosY,inout float D, inout float E, inout float P, inout float T, inout float H, inout float III, inout float DD )
-{
-    float PosXD = -0.035+PosX, offsetD = 0.001;D = all( abs(float2( texcoord.x -PosXD, texcoord.y-PosY)) < float2(0.0025,0.009));D -= all( abs(float2( texcoord.x -PosXD-offsetD, texcoord.y-PosY)) < float2(0.0025,0.007));
-    float PosXE = -0.028+PosX, offsetE = 0.0005;E = all( abs(float2( texcoord.x -PosXE, texcoord.y-PosY)) < float2(0.003,0.009));E -= all( abs(float2( texcoord.x -PosXE-offsetE, texcoord.y-PosY)) < float2(0.0025,0.007));E += all( abs(float2( texcoord.x -PosXE, texcoord.y-PosY)) < float2(0.003,0.001));
-    float PosXP = -0.0215+PosX, PosYP = -0.0025+PosY, offsetP = 0.001, offsetP1 = 0.002;P = all( abs(float2( texcoord.x -PosXP, texcoord.y-PosYP)) < float2(0.0025,0.009*0.775));P -= all( abs(float2( texcoord.x -PosXP-offsetP, texcoord.y-PosYP)) < float2(0.0025,0.007*0.680));float C[1];P += all( abs(float2( texcoord.x -PosXP+offsetP1, texcoord.y-PosY)) < float2(0.0005,0.009));    
-    float PosXT = -0.014+PosX, PosYT = -0.008+PosY;T = all( abs(float2( texcoord.x -PosXT, texcoord.y-PosYT)) < float2(0.003,0.001));T += all( abs(float2( texcoord.x -PosXT, texcoord.y-PosY)) < float2(0.000625,0.009));
-    float PosXH = -0.0072+PosX;H = all( abs(float2( texcoord.x -PosXH, texcoord.y-PosY)) < float2(0.002,0.001));H -= all( abs(float2( texcoord.x -PosXH, texcoord.y-PosY)) < float2(0.002,0.009));H += all( abs(float2( texcoord.x -PosXH, texcoord.y-PosY)) < float2(0.00325,0.009));
-    float offsetFive = 0.001, PosX3 = -0.001+PosX;III = all( abs(float2( texcoord.x -PosX3, texcoord.y-PosY)) < float2(0.002,0.009));III -= all( abs(float2( texcoord.x -PosX3 - offsetFive, texcoord.y-PosY)) < float2(0.003,0.007));III += all( abs(float2( texcoord.x -PosX3, texcoord.y-PosY)) < float2(0.002,0.001));
-    float PosXDD = 0.006+PosX, offsetDD = 0.001;DD = all( abs(float2( texcoord.x -PosXDD, texcoord.y-PosY)) < float2(0.0025,0.009));DD -= all( abs(float2( texcoord.x -PosXDD-offsetDD, texcoord.y-PosY)) < float2(0.0025,0.007));
-}
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //SD video
 float LI(in float3 value)
@@ -181,18 +169,9 @@ float4 NFAA(float2 texcoord)
 return NFAA;
 }
 
-void A1(float2 texcoord,float PosX,float PosY,inout float I, inout float N, inout float F, inout float O)
-{
-        float PosXI = 0.0155+PosX, PosYI = 0.004+PosY, PosYII = 0.008+PosY;I = all( abs(float2( texcoord.x - PosXI, texcoord.y - PosY)) < float2(0.003,0.001));I += all( abs(float2( texcoord.x - PosXI, texcoord.y - PosYI)) < float2(0.000625,0.005));I += all( abs(float2( texcoord.x - PosXI, texcoord.y - PosYII)) < float2(0.003,0.001));
-        float PosXN = 0.0225+PosX, PosYN = 0.005+PosY,offsetN = -0.001;N = all( abs(float2( texcoord.x - PosXN, texcoord.y - PosYN)) < float2(0.002,0.004));N -= all( abs(float2( texcoord.x - PosXN, texcoord.y - PosYN - offsetN)) < float2(0.003,0.005));
-        float PosXF = 0.029+PosX, PosYF = 0.004+PosY, offsetF = 0.0005, offsetF1 = 0.001;F = all( abs(float2( texcoord.x -PosXF-offsetF, texcoord.y-PosYF-offsetF1)) < float2(0.002,0.004));F -= all( abs(float2( texcoord.x -PosXF, texcoord.y-PosYF)) < float2(0.0025,0.005));F += all( abs(float2( texcoord.x -PosXF, texcoord.y-PosYF)) < float2(0.0015,0.00075));
-        float PosXO = 0.035+PosX, PosYO = 0.004+PosY;O = all( abs(float2( texcoord.x -PosXO, texcoord.y-PosYO)) < float2(0.003,0.005));O -= all( abs(float2( texcoord.x -PosXO, texcoord.y-PosYO)) < float2(0.002,0.003));
-}
-
 float4 Out(float4 position : SV_Position, float2 texcoord : TEXCOORD) : SV_Target
 {   float3 Color = NFAA(texcoord).rgb;
-    float PosX = 0.9525f*BUFFER_WIDTH*pix.x,PosY = 0.975f*BUFFER_HEIGHT*pix.y,A,B,C,D,E,F,G,H,I,J,K,L,PosXDot = 0.011+PosX, PosYDot = 0.008+PosY;L = all( abs(float2( texcoord.x -PosXDot, texcoord.y-PosYDot)) < float2(0.00075,0.0015));A0(texcoord,PosX,PosY,A,B,C,D,E,F,G );A1(texcoord,PosX,PosY,H,I,J,K);
-    return timer <= 12500 ? A+B+C+D+E+F+G+H+I+J+K+L ? 1-texcoord.y*50.0+48.35f : float4(Color,1.) : float4(Color,1.);
+    return float4(Color,1.);
 }
 
 float4 PostFilter(float4 position : SV_Position, float2 texcoord : TEXCOORD) : SV_Target

--- a/Shaders/NFAA.fx
+++ b/Shaders/NFAA.fx
@@ -39,6 +39,10 @@
  //* Jose Negrete AKA BlueSkyDefender
  //*
  //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+#include "ReShadeUI.fxh"
+#include "ReShade.fxh"
+
 uniform int AA_Adjust <
     ui_type = "drag";
     ui_min = 1; ui_max = 128;
@@ -72,74 +76,77 @@ uniform int View_Mode <
 
 //Total amount of frames since the game started.
 uniform uint framecount < source = "framecount"; >;
+
 ////////////////////////////////////////////////////////////NFAA////////////////////////////////////////////////////////////////////
-#define pix float2(BUFFER_RCP_WIDTH, BUFFER_RCP_HEIGHT)
-
-texture BackBufferTex : COLOR;
-
-sampler BackBuffer
-    {
-        Texture = BackBufferTex;
-    };
-/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-//SD video
+// sRGB Luminance
 float LI(in float3 value)
 {
-    return dot(value.rgb,float3(0.299, 0.587, 0.114));
+    // return dot(value.rgb, float3(0.2126, 0.7152, 0.0722)); // sRGB luminance
+    return dot(value.rgb, float3(0.299, 0.587, 0.114)); // Perceived Luminance
 }
 
 float4 GetBB(float2 texcoord : TEXCOORD)
 {
-    return tex2D(BackBuffer, texcoord);
+    return tex2Dlod(ReShade::BackBuffer, float4(texcoord, 0.0, 0.0));
 }
 
 float4 NFAA(float2 texcoord)
-{    float t, l, r, s, MA = Mask_Adjust;
-  if(View_Mode == 3 )
-    MA = 5.0;
-    float2 UV = texcoord.xy, SW = pix * MA, n; // But, I don't think it's really needed.
+{
     float4 NFAA; // The Edge Seeking code can be adjusted to look for longer edges.
-    // Find Edges
-    t = LI(GetBB( float2( UV.x , UV.y - SW.y ) ).rgb);
-    s = LI(GetBB( float2( UV.x , UV.y + SW.y ) ).rgb);
-    l = LI(GetBB( float2( UV.x - SW.x , UV.y ) ).rgb);
-    r = LI(GetBB( float2( UV.x + SW.x , UV.y ) ).rgb);
-    n = float2(t - s,-(r - l));
-    // I should have made rep adjustable. But, I didn't see the need.
-    // Since my goal was to make this AA fast cheap and simple.
-  float nl = length(n), Rep = rcp(AA_Adjust);
-    if(View_Mode == 3 || View_Mode == 4)
+    float2 n; // But, I don't think it's really needed.
+    float t, l, r, b;
+    float MA = Mask_Adjust;
+    float Rep = rcp(AA_Adjust);
+    if (View_Mode == 3) {
+        // DLSS
+        MA = 5.0;
         Rep = rcp(128);
+    }
+    float2 SW = BUFFER_PIXEL_SIZE * MA;
+    float2 UV = texcoord.xy;
+    
+    // Find Edges
+    t = LI(GetBB(float2(UV.x, UV.y - SW.y)).rgb);
+    b = LI(GetBB(float2(UV.x, UV.y + SW.y)).rgb);
+    l = LI(GetBB(float2(UV.x - SW.x, UV.y)).rgb);
+    r = LI(GetBB(float2(UV.x + SW.x, UV.y)).rgb);
+    n = float2(t - b, l - r);
+	float nl = length(n);
+    
     // Seek aliasing and apply AA. Think of this as basically blur control.
     if (nl < Rep)
-    {
+	{
+        // face
           NFAA = GetBB(UV);
     }
     else
-    {
-          n *= pix / (nl * (View_Mode == 3 ? 0.5 : 1.0));
+	{
+        // edge
+        n *= BUFFER_PIXEL_SIZE / nl;
+        if (View_Mode == 3) n *= 2.0;
 
-    float4   o = GetBB( UV ),
-            t0 = GetBB( UV + float2(n.x, -n.y)  * 0.5) * 0.9,
-            t1 = GetBB( UV - float2(n.x, -n.y)  * 0.5) * 0.9,
-            t2 = GetBB( UV + n * 0.9) * 0.75,
-            t3 = GetBB( UV - n * 0.9) * 0.75;
+        float4 o = GetBB(UV),
+                t0 = GetBB(UV + float2(n.x, -n.y) * 0.5) * 0.9,
+                t1 = GetBB(UV - float2(n.x, -n.y) * 0.5) * 0.9,
+                t2 = GetBB(UV + n * 0.9) * 0.75,
+                t3 = GetBB(UV - n * 0.9) * 0.75;
 
         NFAA = (o + t0 + t1 + t2 + t3) / 4.3;
     }
+
     // Lets make that mask for a sharper image.
     float Mask = nl * 5.0;
     if (Mask > 0.025)
-        Mask = 1-Mask;
+        Mask = 1 - Mask;
     else
         Mask = 1;
     // Super Evil Magic Number.
-    Mask = saturate(lerp(Mask,1,-1));
+    Mask = saturate(lerp(Mask, 1, -1));
 
     // Final color
     if(View_Mode == 0)
     {
-        NFAA = lerp(NFAA,GetBB( texcoord.xy), Mask );
+        NFAA = lerp(NFAA, GetBB(UV), Mask);
     }
     else if(View_Mode == 1)
     {
@@ -147,34 +154,23 @@ float4 NFAA(float2 texcoord)
     }
     else if (View_Mode == 2)
     {
-        NFAA = float3(-float2(-(r - l),-(t - s)) * 0.5 + 0.5,1);
+        NFAA = float3(-float2(-(r - l), -(t - b)) * 0.5 + 0.5, 1.0);
     }
-
-return NFAA;
+	return NFAA;
 }
 
 float4 Out(float4 position : SV_Position, float2 texcoord : TEXCOORD) : SV_Target
-{   float3 Color = NFAA(texcoord).rgb;
-    return float4(Color,1.);
-}
-
-///////////////////////////////////////////////////////////ReShade.fxh/////////////////////////////////////////////////////////////
-
-// Vertex shader generating a triangle covering the entire screen
-void PostProcessVS(in uint id : SV_VertexID, out float4 position : SV_Position, out float2 texcoord : TEXCOORD)
 {
-    texcoord.x = (id == 2) ? 2.0 : 0.0;
-    texcoord.y = (id == 1) ? 2.0 : 0.0;
-    position = float4(texcoord * float2(2.0, -2.0) + float2(-1.0, 1.0), 0.0, 1.0);
+	float3 Color = NFAA(texcoord).rgb;
+    return float4(Color, 1.0);
 }
 
 //*Rendering passes*//
 technique Normal_Filter_Anti_Aliasing
 {
-            pass NFAA_Fast
+		pass NFAA_Fast
         {
             VertexShader = PostProcessVS;
             PixelShader = Out;
         }
-
 }

--- a/Shaders/NFAA.fx
+++ b/Shaders/NFAA.fx
@@ -51,7 +51,7 @@ uniform int EdgeDetectionType < __UNIFORM_COMBO_INT1
 uniform float EdgeDetectionThreshold < __UNIFORM_DRAG_FLOAT1
 	ui_label = "Edge Detection Threshold";
     ui_tooltip = "If NFAA misses some edges try lowering this slightly.\n"
-				 "Default is 0.063";
+				 "Default is 0.100";
     ui_min = 0.050; ui_max = 0.200;
 > = 0.100;
 
@@ -268,7 +268,7 @@ float4 Out(float4 position : SV_Position, float2 texcoord : TEXCOORD) : SV_Targe
 }
 
 //*Rendering passes*//
-technique Normal_Filter_Anti_Aliasing
+technique NFAA
 {
 		pass NFAA_Fast
         {


### PR DESCRIPTION
- Removed HFR (2nd draw pass hurt performance and benefit seemed very subjective)
  - Might be worth adding this back in but as a separate technique, but I personally found the shifting annoying.
- Removed DLSS parody view
  - I wanted to keep it, but other changes broke it, sorry.
- Removed unused functions or functions performing unused work
  - I have no idea why those functions existed as they never passed data to color output and thus were simply performance costs.
- Rewrite UI for more customization and more consistent control naming
  - I tried to keep things similar to SweetFX SMAA controls
- Add Perceived Luminance and Color edge detection types
- Rewrite NFAA edge detection for more accurate results
- Add corner detection to prevent blurring text and icons
- Add Corner Mask view, Pre-Blur Mask view, and Post-Blur Mask view
- Rewrite NFAA blur algorithm for more consistent results
  - With Blur Strength set to 1.500, and the rest of the controls left at defaults, it produces very similar results to the original.
  - With above settings, it has a slight benefit over the original in less blurred text and small icons.